### PR TITLE
fix humidity setters to handle unexpected data

### DIFF
--- a/src/main/java/com/github/prominence/openweathermap/api/model/Humidity.java
+++ b/src/main/java/com/github/prominence/openweathermap/api/model/Humidity.java
@@ -44,15 +44,13 @@ public class Humidity {
     }
 
     /**
-     * Creates {@link Humidity} object with correctness check.
+     * Creates {@link Humidity} object with safeguard to have min 0 and max 100 as value
      * @param value humidity
      * @return created {@link Humidity} object
      */
     public static Humidity withValue(byte value) {
-        if (value < 0 || value > 100)  {
-            throw new IllegalArgumentException("Humidity value must be in [0, 100] range.");
-        }
-        return new Humidity(value);
+        int v = Math.max(0, Math.min(100, value));
+        return new Humidity((byte) v);
     }
 
     /**
@@ -68,13 +66,10 @@ public class Humidity {
      * Sets humidity percentage value.
      *
      * @param value new humidity value.
-     * @throws IllegalArgumentException in case if provided value isn't in allowed range.
+     * Rounds to 0 or 100 if provided value isn't in allowed range.
      */
     public void setValue(int value) {
-        if (value < 0 || value > 100)  {
-            throw new IllegalArgumentException("Humidity value must be in [0, 100] range.");
-        }
-        this.value = value;
+        this.value = Math.max(0, Math.min(100, value));
     }
 
     /**

--- a/src/test/java/com/github/prominence/openweathermap/api/model/HumidityUnitTest.java
+++ b/src/test/java/com/github/prominence/openweathermap/api/model/HumidityUnitTest.java
@@ -37,13 +37,15 @@ public class HumidityUnitTest {
     }
 
     @Test
-    public void whenCreateHumidityByConstructorWithInvalidDataAboveHundred_thenThrowAnException() {
-        assertThrows(IllegalArgumentException.class, () -> Humidity.withValue((byte) 112));
+    public void whenCreateHumidityByConstructorWithInvalidDataAboveHundred_thenValueIsMaxHundred() {
+        Humidity h = Humidity.withValue((byte) 112);
+        assertEquals(100, h.getValue());
     }
 
     @Test
-    public void whenCreateHumidityByConstructorWithInvalidDataNegative_thenThrowAnException() {
-        assertThrows(IllegalArgumentException.class, () -> Humidity.withValue((byte) -33));
+    public void whenCreateHumidityByConstructorWithInvalidDataNegative_thenValueIsMinZero() {
+        Humidity h = Humidity.withValue((byte) -33);
+        assertEquals(0, h.getValue());
     }
 
     @Test
@@ -59,15 +61,17 @@ public class HumidityUnitTest {
     }
 
     @Test
-    public void whenCreateHumidityAndSetInvalidDataAboveHundred_thenThrowAnException() {
+    public void whenCreateHumidityAndSetInvalidDataAboveHundred_thenValueIsMaxHundred() {
         Humidity humidity = Humidity.withValue((byte) 12);
-        assertThrows(IllegalArgumentException.class, () -> humidity.setValue((byte) 112));
+        humidity.setValue(112);
+        assertEquals(100, humidity.getValue());
     }
 
     @Test
-    public void whenCreateHumidityAndSetInvalidDataNegative_thenThrowAnException() {
+    public void whenCreateHumidityAndSetInvalidDataNegative_thenValueIsMinZero() {
         Humidity humidity = Humidity.withValue((byte) 88);
-        assertThrows(IllegalArgumentException.class, () -> humidity.setValue((byte) -89));
+        humidity.setValue(-89);
+        assertEquals(0, humidity.getValue());
     }
 
     @Test


### PR DESCRIPTION
**fix humidity to handle unexpected data**

it may happen that as a result of current weather api call we get humidity data such as this one (more than 100)

<img width="1516" height="498" alt="image" src="https://github.com/user-attachments/assets/aa0d50ae-da21-484c-8c8d-b4d653710ee0" />

previous implementation was throwing an exception which does not allow clients of the library to handle it gracefully

the PR suggests to round the data to min 0 or max 100

